### PR TITLE
Add safe area support for viewport-fit cover

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>MotoShots</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap"

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,10 @@ body { @apply font-sans; }
 }
 
 .container-max{ max-width: var(--container); margin-left:auto; margin-right:auto; }
+
+@supports (padding: env(safe-area-inset-top)) {
+  body {
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}


### PR DESCRIPTION
## Summary
- include viewport-fit=cover in meta viewport
- add safe-area padding when viewport-fit covers notch areas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: Permission denied)*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm ci` *(fails: 403 Forbidden for @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68b674f6c3208321ba9f10a49a834763