### PR TITLE
Improve responsive grid for benefits section

### DIFF
--- a/src/publico/Home.jsx
+++ b/src/publico/Home.jsx
@@ -20,7 +20,7 @@ export default function Home(){
           <img className='h-[360px] w-full object-cover' alt='Biker' src='https://images.unsplash.com/photo-1515955656352-a1fa3ffcd111?q=80&w=1600&auto=format&fit=crop'/>
         </div>
       </section>
-      <div className='container-max grid grid-cols-2 md:grid-cols-4 gap-3 px-5 mt-4'>
+      <div className='container-max grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 px-5 mt-4'>
         {pills.map(p => <div key={p} className='bg-white border border-slate-200 rounded-full px-4 py-3 text-center font-semibold'>{p}</div>)}
       </div>
     </main>


### PR DESCRIPTION
## Summary
- enhance Home page benefits grid to show 1 column on very small screens, 2 on small, and 4 on medium+

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b713cbe3c0832199ee9031225f7b6b