### PR TITLE
Wrap mobile nav menus in absolute container

### DIFF
--- a/src/components/HeaderPublic.jsx
+++ b/src/components/HeaderPublic.jsx
@@ -10,15 +10,17 @@ export default function HeaderPublic(){
           <Link to='/' className='flex items-center gap-2 font-extrabold'>
             <span className='w-8 h-8 rounded bg-blue-600 inline-block'/> MotoShots
           </Link>
-          <nav className={'ml-auto lg:ml-0 lg:flex-1 ' + (open?'block':'hidden') + ' lg:block'}>
-            <ul className='flex flex-col lg:flex-row lg:justify-center gap-2 lg:gap-7 font-semibold'>
-              <li><Link to='/' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Inicio</Link></li>
-              <li><Link to='/fotografos' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Fotógrafos</Link></li>
-              <li><Link to='/eventos' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Eventos</Link></li>
-              <li><Link to='/precios' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Precios</Link></li>
-              <li><Link to='/eres-fotografo' className='text-white px-3 py-2 rounded-lg bg-blue-600/90 hover:bg-blue-700 lg:ml-4'>¿Eres fotógrafo?</Link></li>
-            </ul>
-          </nav>
+          <div className={`ml-auto lg:ml-0 lg:flex-1 ${open ? 'absolute top-full left-0 w-full bg-white' : 'hidden'} lg:static lg:block lg:w-auto lg:bg-transparent`}>
+            <nav>
+              <ul className='flex flex-col lg:flex-row lg:justify-center gap-2 lg:gap-7 font-semibold'>
+                <li><Link to='/' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Inicio</Link></li>
+                <li><Link to='/fotografos' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Fotógrafos</Link></li>
+                <li><Link to='/eventos' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Eventos</Link></li>
+                <li><Link to='/precios' className='px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900'>Precios</Link></li>
+                <li><Link to='/eres-fotografo' className='text-white px-3 py-2 rounded-lg bg-blue-600/90 hover:bg-blue-700 lg:ml-4'>¿Eres fotógrafo?</Link></li>
+              </ul>
+            </nav>
+          </div>
           <div className='hidden lg:flex items-center gap-3'>
             <Link to='/login' className='px-4 py-2 rounded-xl border border-slate-200 font-bold bg-white'>Iniciar Sesión</Link>
             <Link to='/signup' className='px-4 py-2 rounded-xl font-bold bg-blue-600 text-white hover:bg-blue-700'>Crear Cuenta Gratis</Link>

--- a/src/components/HeaderUser.jsx
+++ b/src/components/HeaderUser.jsx
@@ -28,16 +28,18 @@ export default function HeaderUser() {
             <span className="w-8 h-8 rounded bg-blue-600 inline-block" /> MotoShots
           </Link>
 
-          <nav className={"ml-auto lg:ml-0 lg:flex-1 " + (open ? "block" : "hidden") + " lg:block"}>
-            <ul className="flex flex-col lg:flex-row lg:justify-center gap-2 lg:gap-7 font-semibold">
-              <li><Link to="/app" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Inicio</Link></li>
-              <li><Link to="/app/historial" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Historial</Link></li>
-              <li><Link to="/app/buscar/configurar" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Buscar</Link></li>
-              <li><Link to="/app/fotografos" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Fotógrafos</Link></li>
-              <li><Link to="/app/perfil" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Perfil</Link></li>
-              <li className="lg:hidden"> <AdminAccessLink /></li>
-            </ul>
-          </nav>
+          <div className={`ml-auto lg:ml-0 lg:flex-1 ${open ? 'absolute top-full left-0 w-full bg-white' : 'hidden'} lg:static lg:block lg:w-auto lg:bg-transparent`}>
+            <nav>
+              <ul className="flex flex-col lg:flex-row lg:justify-center gap-2 lg:gap-7 font-semibold">
+                <li><Link to="/app" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Inicio</Link></li>
+                <li><Link to="/app/historial" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Historial</Link></li>
+                <li><Link to="/app/buscar/configurar" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Buscar</Link></li>
+                <li><Link to="/app/fotografos" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Fotógrafos</Link></li>
+                <li><Link to="/app/perfil" className="px-2 py-2 rounded-lg text-slate-800/80 hover:text-slate-900">Perfil</Link></li>
+                <li className="lg:hidden"> <AdminAccessLink /></li>
+              </ul>
+            </nav>
+          </div>
 
           <div className="hidden lg:flex items-center gap-3">
             <AdminAccessLink />


### PR DESCRIPTION
## Summary
- show mobile nav menus inside absolute, full-width dropdown containers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b714dd9a1c832185681f2fe064ac27